### PR TITLE
Dwarf 5 fixes

### DIFF
--- a/lib/worf/elf_file.rb
+++ b/lib/worf/elf_file.rb
@@ -1,0 +1,65 @@
+module WORF
+  class ELFFile
+    attr_reader :io, :elf
+    def initialize io
+      @io = io
+      @elf = ELFTools::ELFFile.new(io)
+    end
+
+    class Section
+      attr_reader :elf, :name
+      def initialize elf, name
+        @elf = elf
+        @name = name
+      end
+
+      def section
+        @elf.elf.section_by_name @name
+      end
+
+      def name_sym
+        name[1..].to_sym
+      end
+
+      def dwarf_class
+        case name_sym
+        when :debug_abbrev
+          WORF::DebugAbbrev
+        when :debug_info
+          WORF::DebugInfo
+        when :debug_str, :debug_line_str
+          WORF::DebugStrings
+        when :debug_line
+          WORF::DebugLine
+        when :debug_str_offs
+          WORF::DebugLine
+        else
+          raise NotImplementedError, "don't have a dwarf_class for #{name_sym.inspect}"
+        end
+      end
+
+      def offset
+        section.header.sh_offset
+      end
+
+      def size
+        section.header.sh_size
+      end
+
+      def as_dwarf
+        raise NotImplementedError, "load WORF" unless defined?(::WORF)
+
+        dwarf_class.new(@elf.io, self, 0)
+      end
+    end
+
+    def find_section name
+      name = name.to_s.gsub(/\A[_.]*/, ".")
+      unless @elf.section_by_name name
+        #warn "could not find section: #{name.inspect} in #{@elf.sections.map(&:name)}"
+        return nil
+      end
+      Section.new(self, name)
+    end
+  end
+end


### PR DESCRIPTION
Fixes a few issues I'm running into under arch linux+gcc

* `DW_FORM_implicit_const` is immediately followed by a signed LEB128 value, which was causing tags to be read incorrectly
* `DW_FORM_line_strp` is similar to `DW_FORM_strp` but it reads from the `.debug_line_str` section instead of `.debug_str`
  * ~I haven't implemented the actual reading yet. It might be helpful to pass around some sort of file adapter object rather than individual sections~ Solved by passing multiple sections to `name`

![](https://64.media.tumblr.com/a5924b204008ffaaafe3e9d106912c22/tumblr_osv0k6A31f1trbh6do1_400.gif)